### PR TITLE
adds TARGET_BASEPATH config var, overriding PACKAGE_NAME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ include config.mk
 PWD=$(shell pwd)
 export PATH := $(PWD)/toolchain/$(ANDROID_PLATFORM)/bin:$(PATH)
 
+TARGET_BASEPATH ?= /data/data/$(PACKAGE_NAME)
 
 .PHONY: all clean spotless host target update
 
@@ -39,12 +40,12 @@ target:
 			TARGET_FEATURES="-no-feature x86 -no-feature x86-64 -feature arm -feature android" \
 			DEBUGBUILD=$(DEBUGBUILD) \
 			ARCH= \
-			PREFIX=/data/data/$(PACKAGE_NAME) \
+			PREFIX=$(TARGET_BASEPATH) \
 			DESTDIR=$(PWD)/build/target \
-			EGGDIR=/data/data/$(PACKAGE_NAME)/lib \
+			EGGDIR=$(TARGET_BASEPATH)/lib \
 		confclean clean all install
-	mkdir -p build/target/data/data/$(PACKAGE_NAME)/lib/chicken/7
-	mv build/target/data/data/$(PACKAGE_NAME)/lib/*.import.* build/target/data/data/$(PACKAGE_NAME)/lib/chicken/7/
+	mkdir -p build/target/$(TARGET_BASEPATH)/lib/chicken/7
+	mv build/target/$(TARGET_BASEPATH)/lib/*.import.* build/target/$(TARGET_BASEPATH)/lib/chicken/7/
 
 build/host/: src/chicken-core/ build/target/
 	$(MAKE) host
@@ -59,8 +60,8 @@ host:
 			TARGET_C_COMPILER=$$PWD/../../toolchain/$(ANDROID_PLATFORM)/bin/arm-linux-androideabi-gcc \
 			DEBUGBUILD=$(DEBUGBUILD) \
 			PREFIX=$(PWD)/build/host \
-			TARGET_PREFIX=$(PWD)/build/target/data/data/$(PACKAGE_NAME) \
-			TARGET_RUN_PREFIX=/data/data/$(PACKAGE_NAME) \
+			TARGET_PREFIX=$(PWD)/build/target/$(TARGET_BASEPATH) \
+			TARGET_RUN_PREFIX=$(TARGET_BASEPATH) \
 			PROGRAM_PREFIX=android- \
 		confclean clean all install
 


### PR DESCRIPTION
in case you want to install or use chicken system-wide, for example,
and not use chicken somewhere under /data/data.

note that TARHET_BASEPATH will overrride PACKAGE_NAME, but if TARGET_BASEPATH is not present, PACKAGE_NAME will be used instead.
